### PR TITLE
chore: conform package name to springworks standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-server-tester",
+  "name": "@springworks/server-tester",
   "version": "0.0.0",
   "description": "",
   "files": [


### PR DESCRIPTION
Readme already had the correct name.